### PR TITLE
Add CI/CD pipeline and container registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,12 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '8.0.x'
+        dotnet-version: |
+          8.0.x
+          9.0.x
 
-    - name: Restore dependencies
-      run: dotnet restore
-
-    - name: Build
-      run: dotnet build --configuration Release --no-restore
+    - name: Build web project
+      run: dotnet build src/JunoBank.Web/JunoBank.Web.csproj --configuration Release
 
     - name: Unit tests
-      run: dotnet test tests/JunoBank.Tests --configuration Release --no-build --verbosity normal
+      run: dotnet test tests/JunoBank.Tests/JunoBank.Tests.csproj --configuration Release --verbosity normal

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [master]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '8.0.x'
+
+    - name: Restore dependencies
+      run: dotnet restore
+
+    - name: Build
+      run: dotnet build --configuration Release --no-restore
+
+    - name: Unit tests
+      run: dotnet test tests/JunoBank.Tests --configuration Release --no-build --verbosity normal

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,15 @@
-name: Release Build
+name: Release
 
 on:
-  release:
-    types: [published]
+  push:
+    branches: [master]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  build-and-test:
+  test:
     runs-on: ubuntu-latest
 
     steps:
@@ -22,21 +26,40 @@ jobs:
     - name: Build
       run: dotnet build --configuration Release --no-restore
 
-    - name: Test
-      run: dotnet test --configuration Release --no-build --verbosity normal
+    - name: Unit tests
+      run: dotnet test tests/JunoBank.Tests --configuration Release --no-build --verbosity normal
 
   docker:
-    needs: build-and-test
+    needs: test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
 
     steps:
     - uses: actions/checkout@v4
 
-    - name: Build Docker image
-      run: |
-        docker build -t junobank:${{ github.ref_name }} -f docker/Dockerfile .
-        docker tag junobank:${{ github.ref_name }} junobank:latest
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
-    # Optional: push to container registry
-    # - name: Push to registry
-    #   run: docker push ...
+    - name: Extract metadata
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        tags: |
+          type=sha
+          type=raw,value=latest
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: docker/Dockerfile
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,16 +18,15 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '8.0.x'
+        dotnet-version: |
+          8.0.x
+          9.0.x
 
-    - name: Restore dependencies
-      run: dotnet restore
-
-    - name: Build
-      run: dotnet build --configuration Release --no-restore
+    - name: Build web project
+      run: dotnet build src/JunoBank.Web/JunoBank.Web.csproj --configuration Release
 
     - name: Unit tests
-      run: dotnet test tests/JunoBank.Tests --configuration Release --no-build --verbosity normal
+      run: dotnet test tests/JunoBank.Tests/JunoBank.Tests.csproj --configuration Release --verbosity normal
 
   docker:
     needs: test

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,9 +2,7 @@ version: "3.8"
 
 services:
   junobank:
-    build:
-      context: ..
-      dockerfile: docker/Dockerfile
+    image: ghcr.io/tzeetzch/juno-z:latest
     container_name: junobank
     restart: unless-stopped
     ports:


### PR DESCRIPTION
## Summary
- **CI workflow** (`ci.yml`): Runs build + unit tests on every pull request to master
- **Release workflow** (`release.yml`): On merge to master — runs tests, builds Docker image, pushes to ghcr.io
- **docker-compose.yml**: Now pulls pre-built image from `ghcr.io/tzeetzch/juno-z:latest` instead of building locally

## What changes for deployment

**Before:**
```bash
git pull && docker-compose up -d --build
```

**After:**
```bash
docker pull ghcr.io/tzeetzch/juno-z:latest
docker-compose up -d
```

No source code or build tools needed on the server.

## Test plan
- [ ] CI workflow runs on this PR (check Actions tab)
- [ ] Merge triggers release workflow and pushes image to ghcr.io
- [ ] Verify image at github.com/Tzeetzch/Juno-Z/pkgs/container/juno-z