### PR TITLE
Fix email settings not refreshing after save

### DIFF
--- a/src/JunoBank.Web/Components/Pages/Parent/Settings.razor
+++ b/src/JunoBank.Web/Components/Pages/Parent/Settings.razor
@@ -210,6 +210,10 @@
         var dialog = await DialogService.ShowAsync<EmailSettingsDialog>(
             null, parameters, new DialogOptions { MaxWidth = MaxWidth.Small, FullWidth = true });
 
-        await dialog.Result;
+        var result = await dialog.Result;
+        if (result is { Canceled: false })
+        {
+            StateHasChanged();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Settings page now refreshes email status after saving in the dialog
- Added `StateHasChanged()` call after dialog closes (same pattern as notification dialog)

## Root cause
`OpenEmailDialog()` awaited the dialog result but didn't trigger a re-render, so `EmailConfigService.IsConfigured` wasn't re-evaluated.

Fixes #9