### PR TITLE
Fix email config always showing not configured

### DIFF
--- a/src/JunoBank.Web/Components/Pages/Parent/Settings.razor
+++ b/src/JunoBank.Web/Components/Pages/Parent/Settings.razor
@@ -211,5 +211,6 @@
             null, parameters, new DialogOptions { MaxWidth = MaxWidth.Small, FullWidth = true });
 
         await dialog.Result;
+        StateHasChanged();
     }
 }

--- a/src/JunoBank.Web/Program.cs
+++ b/src/JunoBank.Web/Program.cs
@@ -12,7 +12,10 @@ using MudBlazor.Services;
 var builder = WebApplication.CreateBuilder(args);
 
 // Load email config from data volume (written by setup wizard, persists across restarts)
-var emailConfigPath = Path.Combine("Data", "email-config.json");
+// Derive path from connection string so it matches EmailConfigService.GetConfigPath() on all platforms
+var connStr = builder.Configuration.GetConnectionString("DefaultConnection") ?? "Data Source=Data/junobank.db";
+var dataDir = Path.GetDirectoryName(connStr.Replace("Data Source=", "")) ?? "Data";
+var emailConfigPath = Path.Combine(dataDir, "email-config.json");
 builder.Configuration.AddJsonFile(emailConfigPath, optional: true, reloadOnChange: true);
 
 // Add services to the container.


### PR DESCRIPTION
## Summary
- Fix path mismatch that caused email settings to always show "Not configured" on Docker/Linux
- Add UI refresh after email settings dialog closes

## Root cause
`Program.cs` hardcoded the email config path as `Data/email-config.json`, while `EmailConfigService` derived it from the connection string. On Docker, the connection string is `Data Source=/app/data/junobank.db`, so the service wrote to `/app/data/email-config.json` — a different path on case-sensitive Linux.

## Fix
Derive the path from the connection string in both places (2-line change in Program.cs).

## Test plan
- [x] 154 unit tests pass
- [ ] CI passes
- [ ] Deploy to Docker, configure email via settings dialog, verify it shows "SMTP configured"

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)