### PR TITLE
Fix race condition in balance updates (#13)

### DIFF
--- a/src/JunoBank.Core/Data/AppDbContext.cs
+++ b/src/JunoBank.Core/Data/AppDbContext.cs
@@ -28,6 +28,7 @@ public class AppDbContext : DbContext
             entity.Property(e => e.Name).IsRequired().HasMaxLength(100);
             entity.Property(e => e.Email).HasMaxLength(200);
             entity.Property(e => e.Balance).HasPrecision(18, 2);
+            entity.Property(e => e.ConcurrencyStamp).IsConcurrencyToken();
 
             // One-to-one with PicturePassword
             entity.HasOne(e => e.PicturePassword)

--- a/src/JunoBank.Core/Data/Entities/User.cs
+++ b/src/JunoBank.Core/Data/Entities/User.cs
@@ -24,6 +24,9 @@ public class User
     // Balance
     public decimal Balance { get; set; }
 
+    // Concurrency control for balance updates
+    public int ConcurrencyStamp { get; set; }
+
     // Timestamps
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 

--- a/src/JunoBank.Core/Data/Migrations/20260219114946_AddBalanceConcurrencyStamp.Designer.cs
+++ b/src/JunoBank.Core/Data/Migrations/20260219114946_AddBalanceConcurrencyStamp.Designer.cs
@@ -3,16 +3,19 @@ using System;
 using JunoBank.Web.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
 
-namespace JunoBank.Web.Migrations
+namespace JunoBank.Web.Data.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260219114946_AddBalanceConcurrencyStamp")]
+    partial class AddBalanceConcurrencyStamp
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "8.0.24");

--- a/src/JunoBank.Core/Data/Migrations/20260219114946_AddBalanceConcurrencyStamp.cs
+++ b/src/JunoBank.Core/Data/Migrations/20260219114946_AddBalanceConcurrencyStamp.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace JunoBank.Web.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddBalanceConcurrencyStamp : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "ConcurrencyStamp",
+                table: "Users",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ConcurrencyStamp",
+                table: "Users");
+        }
+    }
+}

--- a/src/JunoBank.Core/Services/AllowanceService.cs
+++ b/src/JunoBank.Core/Services/AllowanceService.cs
@@ -60,6 +60,7 @@ public class AllowanceService : IAllowanceService
 
                 // Update child's balance
                 allowance.Child.Balance += allowance.Amount;
+                allowance.Child.ConcurrencyStamp++;
 
                 // Update schedule tracking — calculate next run in user's timezone, store as UTC
                 allowance.LastRunDate = allowance.NextRunDate;


### PR DESCRIPTION
## Summary
- Add `ConcurrencyStamp` (int) to `User` entity as an EF Core concurrency token
- Wrap balance-modifying methods in `UserService` with retry logic that detaches tracked entities and re-fetches on `DbUpdateConcurrencyException` (up to 3 retries)
- Increment stamp in `AllowanceService` balance updates (no retry needed — background service has built-in catch-up)

## What changed
| File | Change |
|------|--------|
| `User.cs` | New `ConcurrencyStamp` property |
| `AppDbContext.cs` | `.IsConcurrencyToken()` configuration |
| Migration | `AddBalanceConcurrencyStamp` — adds INTEGER column default 0 |
| `UserService.cs` | `ExecuteWithConcurrencyRetryAsync` helper; wrapped `ResolveRequestAsync`, `CreateManualTransactionAsync`, `CreateManualTransactionForChildAsync` |
| `AllowanceService.cs` | `ConcurrencyStamp++` after balance update |
| Tests | 6 new tests verifying stamp increment/non-increment behavior |

## How it prevents overdraft
EF Core adds `WHERE ConcurrencyStamp = @original` to the UPDATE. If two parents approve withdrawals concurrently, the second save fails with `DbUpdateConcurrencyException`. The retry logic re-reads the (now-lower) balance and re-checks sufficiency before retrying.

Closes #13

## Test plan
- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test` — 160/160 passed (6 new concurrency stamp tests)
- [ ] Manual: open two browser tabs, approve two withdrawals exceeding balance simultaneously — second should fail gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)