### PR TITLE
docs: update references for Clean Architecture structure

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -2,7 +2,7 @@
 
 > Available services and utility classes for building features.
 
-## Services (`Services/`)
+## Application Services (`JunoBank.Application/Services/`)
 
 ### IAuthService
 Handles authentication for parents (email/password) and children (picture password). Includes rate limiting (5 attempts → 5-minute lockout for both).
@@ -179,7 +179,7 @@ Task<UserSession?> GetCurrentUserAsync();
 
 ---
 
-## Utilities (`Utils/`)
+## Application Utils (`JunoBank.Application/Utils/`)
 
 ### AppRoutes
 Centralized URL constants. **Always use these instead of magic strings.**
@@ -249,7 +249,68 @@ SecurityUtils.HashPictureSequence("cat,dog,star,moon")  // SHA256 hash (Base64)
 
 ---
 
-## Constants (`Constants/`)
+## Web Utils (`JunoBank.Web/Utils/`)
+
+### AppRoutes
+Centralized URL constants. **Always use these instead of magic strings.**
+
+```csharp
+// Child routes
+AppRoutes.Child.Dashboard           // "/child"
+AppRoutes.Child.RequestDeposit      // "/child/request-deposit"
+AppRoutes.Child.RequestWithdrawal   // "/child/request-withdrawal"
+
+// Parent routes
+AppRoutes.Parent.Dashboard          // "/parent"
+AppRoutes.Parent.PendingRequests    // "/parent/requests"
+AppRoutes.Parent.Settings           // "/parent/settings"
+
+// Parent child-context routes (methods)
+AppRoutes.Parent.ChildDetail(childId)             // "/parent/child/{id}"
+AppRoutes.Parent.ChildRequests(childId)            // "/parent/child/{id}/requests"
+AppRoutes.Parent.ChildRequestHistory(childId)      // "/parent/child/{id}/request-history"
+AppRoutes.Parent.ChildTransactionHistory(childId)  // "/parent/child/{id}/transactions"
+AppRoutes.Parent.ChildTransaction(childId)         // "/parent/child/{id}/transaction"
+AppRoutes.Parent.ChildSettings(childId)            // "/parent/child/{id}/settings"
+AppRoutes.Parent.ChildOrderNew(childId)            // "/parent/child/{id}/order/new"
+AppRoutes.Parent.ChildOrderEdit(childId, orderId)  // "/parent/child/{id}/order/{orderId}"
+
+// Auth routes
+AppRoutes.Auth.Login                // "/login"
+AppRoutes.Auth.ParentLogin          // "/login/parent"
+
+// Setup routes
+AppRoutes.Setup.Wizard              // "/setup"
+```
+
+---
+
+### CurrencyFormatter
+Consistent Euro formatting.
+
+```csharp
+CurrencyFormatter.Format(10.5m)              // "€10.50"
+CurrencyFormatter.FormatWithSign(5m, false)  // "+€5.00" (deposit)
+CurrencyFormatter.FormatWithSign(5m, true)   // "-€5.00" (withdrawal)
+CurrencyFormatter.FormatInvariant(10.5m)     // Invariant culture format
+```
+
+---
+
+### StatusDisplayHelper
+Request status display helpers.
+
+```csharp
+StatusDisplayHelper.GetStatusText(RequestStatus.Pending)   // "Waiting"
+StatusDisplayHelper.GetStatusText(RequestStatus.Approved)  // "Approved"
+StatusDisplayHelper.GetStatusText(RequestStatus.Denied)    // "Denied"
+
+StatusDisplayHelper.GetStatusColor(RequestStatus.Pending)  // "#FFA726" (orange)
+```
+
+---
+
+## Constants (`JunoBank.Web/Constants/`)
 
 ### PicturePasswordImages
 Picture password configuration.
@@ -266,7 +327,7 @@ PicturePasswordImages.GetEmoji("cat")         // "🐱"
 
 ---
 
-## Entities (`Data/Entities/`)
+## Entities (`JunoBank.Domain/Entities/`)
 
 ### User
 ```csharp

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -21,9 +21,12 @@ Standard .NET conventions for Juno Bank.
 - File name matches class name
 - Group by feature, not by type:
   ```
-  Components/Pages/Child/Dashboard.razor  (not Pages/Dashboard.razor)
-  Services/TransactionService.cs          (not Services/ITransactionService.cs + TransactionService.cs in separate folders)
+  src/JunoBank.Web/Components/Pages/Child/Dashboard.razor
+  src/JunoBank.Application/Services/UserService.cs
+  src/JunoBank.Domain/Entities/User.cs
+  src/JunoBank.Infrastructure/Data/AppDbContext.cs
   ```
+- Project placement: Services → Application, Entities → Domain, DbContext/Email → Infrastructure, Components/UI → Web
 
 ## Code Style
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -6,7 +6,7 @@
 
 | Project | Type | Location | Count |
 |---------|------|----------|-------|
-| JunoBank.Tests | xUnit unit tests | `tests/JunoBank.Tests/` | 96 tests |
+| JunoBank.Tests | xUnit unit tests | `tests/JunoBank.Tests/` | 160 tests |
 | E2E | Playwright | `tests/e2e/` | 64 specs |
 
 ---
@@ -29,19 +29,21 @@ tests/JunoBank.Tests/
 ├── BackgroundServices/
 │   └── AllowanceBackgroundServiceTests.cs  # 3 tests
 ├── Services/
-│   ├── AllowanceServiceTests.cs         # 19 tests
+│   ├── AllowanceServiceTests.cs         # 20 tests
 │   ├── AuthServiceTests.cs             # 14 tests (includes rate limiting)
 │   ├── ConsoleEmailServiceTests.cs      # 3 tests
+│   ├── EmailConfigServiceTests.cs       # 10 tests
 │   ├── EmailServiceRegistrationTests.cs # 3 tests
-│   ├── PasswordResetServiceTests.cs     # 20 tests (19 Fact + 1 Theory)
+│   ├── NotificationServiceTests.cs      # 19 tests
+│   ├── PasswordResetServiceTests.cs     # 26 tests (19 Fact + 1 Theory)
 │   ├── SetupServiceTests.cs            # 11 tests
-│   └── UserServiceTests.cs             # 23 tests
+│   └── UserServiceTests.cs             # 51 tests
 └── JunoBank.Tests.csproj
 ```
 
 ### Database Test Base
 
-All service tests inherit from `DatabaseTestBase` for in-memory SQLite:
+All service tests inherit from `DatabaseTestBase` for in-memory SQLite. `Db` is an `AppDbContext` from `JunoBank.Infrastructure.Data`:
 
 ```csharp
 public class MyServiceTests : DatabaseTestBase


### PR DESCRIPTION
## Summary
- Update `docs/API.md` to use project-qualified paths (Application Services, Application Utils, Web Utils, Web Constants, Domain Entities) — closes #27
- Update `docs/TESTING.md` with correct test count (160) and all test files with accurate per-class counts — closes #28
- Update `docs/CONVENTIONS.md` file organization examples to show 4-project structure — closes #29
- Replace `.claude/commands/clean-architecture.md` migration instructions with post-migration reference guide — closes #32

## Test plan
- [x] No code changes — docs only
- [ ] Verify links and paths match actual project structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)