### PR TITLE
chore: remove stale Stryker exclusion

### DIFF
--- a/stryker-config.json
+++ b/stryker-config.json
@@ -4,8 +4,7 @@
     "reporters": ["html", "json", "progress", "cleartext"],
     "mutate": [
       "Services/**/*.cs",
-      "Utils/**/*.cs",
-      "!Services/WeeklySummaryEmailBuilder.cs"
+      "Utils/**/*.cs"
     ],
     "thresholds": {
       "high": 80,


### PR DESCRIPTION
## Summary
- Remove no-op `!Services/WeeklySummaryEmailBuilder.cs` exclusion from `stryker-config.json` — closes #30
- File moved to Infrastructure during restructure; Stryker targets Application, so the line matched nothing

## Test plan
- [x] Config-only change, no code impact
- [ ] Verify Stryker still runs correctly against Application project

🤖 Generated with [Claude Code](https://claude.com/claude-code)