### PR TITLE
fix: log warning on timezone fallback

### DIFF
--- a/src/JunoBank.Application/Services/AllowanceService.cs
+++ b/src/JunoBank.Application/Services/AllowanceService.cs
@@ -211,14 +211,15 @@ public class AllowanceService : IAllowanceService
         }
     }
 
-    private static TimeZoneInfo GetTimeZone(string timeZoneId)
+    private TimeZoneInfo GetTimeZone(string timeZoneId)
     {
         try
         {
             return TimeZoneInfo.FindSystemTimeZoneById(timeZoneId);
         }
-        catch
+        catch (Exception ex)
         {
+            _logger.LogWarning(ex, "Invalid timezone '{TimeZoneId}', falling back to UTC", timeZoneId);
             return TimeZoneInfo.Utc;
         }
     }


### PR DESCRIPTION
## Summary
- Change `GetTimeZone` from static to instance method to access `_logger` — closes #16
- Log `LogWarning` with the invalid timezone ID and exception before falling back to UTC
- Add test verifying invalid timezone doesn't throw and allowance still processes

## Test plan
- [x] `dotnet build` — 0 errors
- [x] `dotnet test` — 161 tests pass (1 new)
- [ ] Verify log output contains timezone warning when invalid ID is used

🤖 Generated with [Claude Code](https://claude.com/claude-code)