### PR TITLE
fix: add SMTP connection timeout

### DIFF
--- a/src/JunoBank.Infrastructure/Email/SmtpEmailService.cs
+++ b/src/JunoBank.Infrastructure/Email/SmtpEmailService.cs
@@ -41,6 +41,7 @@ public class SmtpEmailService : IEmailService
             message.Body = bodyBuilder.ToMessageBody();
 
             using var client = new SmtpClient();
+            client.Timeout = 10000; // 10 seconds
 
             var socketOptions = port switch
             {


### PR DESCRIPTION
## Summary
- Add `client.Timeout = 10000` (10 seconds) to `SmtpEmailService` — closes #17
- Prevents indefinite hanging when SMTP server is unreachable

## Test plan
- [x] `dotnet build` — 0 errors
- [x] 1-line config change, no behavioral test needed
- [ ] Verify SMTP operations time out after 10s when server is unreachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)