### PR TITLE
fix: validate email addresses with MailAddress

### DIFF
--- a/src/JunoBank.Application/Utils/ValidationUtils.cs
+++ b/src/JunoBank.Application/Utils/ValidationUtils.cs
@@ -1,0 +1,19 @@
+using System.Net.Mail;
+
+namespace JunoBank.Application.Utils;
+
+public static class ValidationUtils
+{
+    public static bool IsValidEmail(string email)
+    {
+        try
+        {
+            var addr = new MailAddress(email);
+            return addr.Address == email;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/src/JunoBank.Web/Components/Pages/Auth/ForgotPassword.razor
+++ b/src/JunoBank.Web/Components/Pages/Auth/ForgotPassword.razor
@@ -78,9 +78,9 @@
     {
         _error = string.Empty;
 
-        if (string.IsNullOrWhiteSpace(_email))
+        if (string.IsNullOrWhiteSpace(_email) || !ValidationUtils.IsValidEmail(_email))
         {
-            _error = "Please enter your email address.";
+            _error = "Please enter a valid email address.";
             return;
         }
 

--- a/src/JunoBank.Web/Components/Pages/Setup/SetupStep1.razor
+++ b/src/JunoBank.Web/Components/Pages/Setup/SetupStep1.razor
@@ -65,9 +65,9 @@
             return;
         }
 
-        if (string.IsNullOrWhiteSpace(Model.Email) || !Model.Email.Contains('@'))
+        if (string.IsNullOrWhiteSpace(Model.Email) || !ValidationUtils.IsValidEmail(Model.Email))
         {
-            _error = "Please enter a valid email";
+            _error = "Please enter a valid email address.";
             return;
         }
 

--- a/src/JunoBank.Web/Components/Pages/Setup/SetupStep2.razor
+++ b/src/JunoBank.Web/Components/Pages/Setup/SetupStep2.razor
@@ -112,9 +112,9 @@ else
             return;
         }
 
-        if (string.IsNullOrWhiteSpace(Model.Email) || !Model.Email.Contains('@'))
+        if (string.IsNullOrWhiteSpace(Model.Email) || !ValidationUtils.IsValidEmail(Model.Email))
         {
-            _error = "Please enter a valid email";
+            _error = "Please enter a valid email address.";
             return;
         }
 

--- a/src/JunoBank.Web/Components/_Imports.razor
+++ b/src/JunoBank.Web/Components/_Imports.razor
@@ -10,6 +10,7 @@
 @using Microsoft.JSInterop
 @using JunoBank.Application.DTOs
 @using JunoBank.Application.Interfaces
+@using JunoBank.Application.Utils
 @using JunoBank.Domain.Entities
 @using JunoBank.Domain.Enums
 @using JunoBank.Web


### PR DESCRIPTION
## Summary
- Replace weak `Contains('@')` email checks with `System.Net.Mail.MailAddress` validation — closes #18
- Extract `ValidationUtils.IsValidEmail()` to `JunoBank.Application/Utils/` (used in 3 places)
- Updated: `SetupStep1.razor`, `SetupStep2.razor`, `ForgotPassword.razor`

## Test plan
- [x] `dotnet build` — 0 errors
- [x] `dotnet test` — 160 tests pass
- [ ] Verify invalid emails (e.g., `foo@`, `@bar.com`, `no spaces@test.com`) are rejected in setup wizard and forgot password

🤖 Generated with [Claude Code](https://claude.com/claude-code)