### PR TITLE
feat: add bUnit component test project

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -6,7 +6,8 @@
 
 | Project | Type | Location | Count |
 |---------|------|----------|-------|
-| JunoBank.Tests | xUnit unit tests | `tests/JunoBank.Tests/` | 96 tests |
+| JunoBank.Tests | xUnit unit tests | `tests/JunoBank.Tests/` | 160 tests |
+| JunoBank.Web.Tests | bUnit component tests | `tests/JunoBank.Web.Tests/` | 21 tests |
 | E2E | Playwright | `tests/e2e/` | 64 specs |
 
 ---
@@ -96,6 +97,88 @@ public void CalculateNextRunDate_Weekly_SameDayAfterTime_ReturnsNextWeek()
 [Fact]
 public async Task ProcessDueAllowances_AllowanceIsDue_CreatesTransaction()
 ```
+
+---
+
+## Component Tests (bUnit)
+
+### Running Tests
+
+```bash
+cd tests/JunoBank.Web.Tests
+dotnet test
+```
+
+### Why a Separate Project?
+
+`JunoBank.Tests` deliberately does NOT reference the Web project (clean architecture boundary). `JunoBank.Web.Tests` exists specifically for testing Blazor components in isolation.
+
+### Test Structure
+
+```
+tests/JunoBank.Web.Tests/
+├── Helpers/
+│   └── ComponentTestBase.cs               # MudBlazor + mock setup
+├── Components/Shared/
+│   ├── ChildCardTests.cs                  # 6 tests (presentational)
+│   ├── PictureGridTests.cs                # 7 tests (stateful)
+│   └── TransactionListTests.cs            # 8 tests (service-injected)
+├── _Imports.razor
+└── JunoBank.Web.Tests.csproj
+```
+
+### Component Test Base
+
+All component tests inherit from `ComponentTestBase` for MudBlazor and mock setup:
+
+```csharp
+public class MyComponentTests : ComponentTestBase
+{
+    [Fact]
+    public void Render_ShowsExpectedContent()
+    {
+        var cut = RenderComponent<MyComponent>(p => p
+            .Add(x => x.SomeParam, "value"));
+
+        Assert.Contains("value", cut.Markup);
+    }
+}
+```
+
+`ComponentTestBase` provides:
+- MudBlazor services registered
+- `JSInterop.Mode = JSRuntimeMode.Loose` (handles MudBlazor JS calls)
+- `MockBrowserTime` pre-configured (returns input unchanged by default)
+
+### Key Patterns
+
+**Re-query after state changes** — bUnit's `FindAll` returns a snapshot. After clicks that trigger re-renders, call `FindAll` again:
+
+```csharp
+// WRONG — stale reference after re-render
+var buttons = cut.FindAll("button");
+buttons[0].Click();
+buttons[1].Click();  // May throw UnknownEventHandlerIdException
+
+// CORRECT — re-query each time
+cut.FindAll("button")[0].Click();
+cut.FindAll("button")[1].Click();
+```
+
+**Use InvokeAsync for direct method calls** — Methods that call `StateHasChanged()` must run on the render dispatcher:
+
+```csharp
+cut.InvokeAsync(() => cut.Instance.Reset());
+```
+
+### When to Use bUnit vs E2E
+
+| Use bUnit when... | Use Playwright when... |
+|---|---|
+| Testing component rendering logic | Testing full user flows |
+| Verifying parameter/callback behavior | Testing auth, navigation, sessions |
+| Testing conditional display | Testing cross-component integration |
+| Fast feedback (ms per test) | Realistic browser behavior needed |
 
 ---
 
@@ -246,6 +329,12 @@ await expect(page).toHaveURL(/\/parent/, { timeout: 15000 });
 - **Services:** Business logic, calculations, database operations
 - **Utilities:** Formatters, helpers, hash functions
 - **Background services:** Scheduled task processing
+
+### Component Tests (bUnit)
+
+- **Presentational components:** Correct rendering based on parameters
+- **Stateful components:** Internal state changes, user interactions
+- **Service-injected components:** Correct use of injected services (mock them)
 
 ### E2E Tests
 

--- a/tests/JunoBank.Web.Tests/Components/Shared/ChildCardTests.cs
+++ b/tests/JunoBank.Web.Tests/Components/Shared/ChildCardTests.cs
@@ -1,0 +1,74 @@
+using Bunit;
+using JunoBank.Application.DTOs;
+using JunoBank.Web.Components.Shared;
+using JunoBank.Web.Tests.Helpers;
+
+namespace JunoBank.Web.Tests.Components.Shared;
+
+public class ChildCardTests : ComponentTestBase
+{
+    private static ChildSummary CreateChild(
+        string name = "Junior", decimal balance = 10.50m, int pending = 0) =>
+        new() { Id = 1, Name = name, Balance = balance, PendingRequestCount = pending };
+
+    [Fact]
+    public void Render_ShowsChildName()
+    {
+        var cut = RenderComponent<ChildCard>(p => p
+            .Add(x => x.Child, CreateChild("Junior")));
+
+        Assert.Contains("Junior", cut.Find(".child-name").TextContent);
+    }
+
+    [Fact]
+    public void Render_ShowsFormattedBalance()
+    {
+        var cut = RenderComponent<ChildCard>(p => p
+            .Add(x => x.Child, CreateChild(balance: 10.50m)));
+
+        Assert.Contains("10.50", cut.Find(".balance-value").TextContent);
+    }
+
+    [Fact]
+    public void Render_ShowsFirstLetterAsAvatar()
+    {
+        var cut = RenderComponent<ChildCard>(p => p
+            .Add(x => x.Child, CreateChild("Sophie")));
+
+        Assert.Equal("S", cut.Find(".child-avatar").TextContent);
+    }
+
+    [Fact]
+    public void Render_WithPendingRequests_ShowsPendingBadge()
+    {
+        var cut = RenderComponent<ChildCard>(p => p
+            .Add(x => x.Child, CreateChild(pending: 3)));
+
+        var badge = cut.Find(".pending-badge");
+        Assert.Contains("3 pending", badge.TextContent);
+    }
+
+    [Fact]
+    public void Render_WithNoPendingRequests_HidesPendingBadge()
+    {
+        var cut = RenderComponent<ChildCard>(p => p
+            .Add(x => x.Child, CreateChild(pending: 0)));
+
+        Assert.Empty(cut.FindAll(".pending-badge"));
+    }
+
+    [Fact]
+    public void Click_InvokesOnClickCallback()
+    {
+        ChildSummary? clicked = null;
+        var child = CreateChild();
+
+        var cut = RenderComponent<ChildCard>(p => p
+            .Add(x => x.Child, child)
+            .Add(x => x.OnClick, c => clicked = c));
+
+        cut.Find(".child-card").Click();
+
+        Assert.Equal(child, clicked);
+    }
+}

--- a/tests/JunoBank.Web.Tests/Components/Shared/PictureGridTests.cs
+++ b/tests/JunoBank.Web.Tests/Components/Shared/PictureGridTests.cs
@@ -1,0 +1,88 @@
+using Bunit;
+using JunoBank.Web.Components.Shared;
+using JunoBank.Web.Constants;
+using JunoBank.Web.Tests.Helpers;
+
+namespace JunoBank.Web.Tests.Components.Shared;
+
+public class PictureGridTests : ComponentTestBase
+{
+    [Fact]
+    public void Render_ShowsCorrectNumberOfButtons()
+    {
+        var cut = RenderComponent<PictureGrid>();
+
+        Assert.Equal(PicturePasswordImages.GridDisplayCount, cut.FindAll(".picture-btn").Count);
+    }
+
+    [Fact]
+    public void Render_ShowsEmptySequenceDots()
+    {
+        var cut = RenderComponent<PictureGrid>();
+
+        var dots = cut.FindAll(".sequence-dot");
+        Assert.Equal(PicturePasswordImages.DefaultSequenceLength, dots.Count);
+        Assert.Empty(cut.FindAll(".sequence-dot.filled"));
+    }
+
+    [Fact]
+    public void SelectImage_FillsSequenceDot()
+    {
+        var cut = RenderComponent<PictureGrid>();
+
+        cut.FindAll(".picture-btn")[0].Click();
+
+        Assert.Single(cut.FindAll(".sequence-dot.filled"));
+    }
+
+    [Fact]
+    public void SelectFourImages_FiresOnSequenceComplete()
+    {
+        string[]? completedSequence = null;
+        var cut = RenderComponent<PictureGrid>(p => p
+            .Add(x => x.OnSequenceComplete, seq => completedSequence = seq));
+
+        for (int i = 0; i < PicturePasswordImages.DefaultSequenceLength; i++)
+            cut.FindAll(".picture-btn")[i].Click();
+
+        Assert.NotNull(completedSequence);
+        Assert.Equal(PicturePasswordImages.DefaultSequenceLength, completedSequence.Length);
+    }
+
+    [Fact]
+    public void SelectFourImages_DisablesButtons()
+    {
+        var cut = RenderComponent<PictureGrid>(p => p
+            .Add(x => x.OnSequenceComplete, _ => { }));
+
+        for (int i = 0; i < PicturePasswordImages.DefaultSequenceLength; i++)
+            cut.FindAll(".picture-btn")[i].Click();
+
+        // Re-query after state change
+        var updatedButtons = cut.FindAll(".picture-btn");
+        Assert.All(updatedButtons, btn => Assert.True(btn.HasAttribute("disabled")));
+    }
+
+    [Fact]
+    public void Reset_ClearsSelection()
+    {
+        var cut = RenderComponent<PictureGrid>();
+
+        cut.FindAll(".picture-btn")[0].Click();
+        Assert.Single(cut.FindAll(".sequence-dot.filled"));
+
+        cut.InvokeAsync(() => cut.Instance.Reset());
+
+        Assert.Empty(cut.FindAll(".sequence-dot.filled"));
+    }
+
+    [Fact]
+    public void ShowError_DisplaysErrorMessage()
+    {
+        var cut = RenderComponent<PictureGrid>();
+
+        cut.InvokeAsync(() => cut.Instance.ShowError("Wrong password!"));
+
+        Assert.Contains("Wrong password!", cut.Markup);
+    }
+}

--- a/tests/JunoBank.Web.Tests/Components/Shared/TransactionListTests.cs
+++ b/tests/JunoBank.Web.Tests/Components/Shared/TransactionListTests.cs
@@ -1,0 +1,97 @@
+using Bunit;
+using JunoBank.Domain.Entities;
+using JunoBank.Domain.Enums;
+using JunoBank.Web.Components.Shared;
+using JunoBank.Web.Tests.Helpers;
+using Moq;
+
+namespace JunoBank.Web.Tests.Components.Shared;
+
+public class TransactionListTests : ComponentTestBase
+{
+    [Fact]
+    public void Render_EmptyList_ShowsEmptyMessage()
+    {
+        var cut = RenderComponent<TransactionList>();
+
+        Assert.Contains("No transactions yet!", cut.Markup);
+    }
+
+    [Fact]
+    public void Render_ShowsTransactionDescription()
+    {
+        var transactions = new List<Transaction>
+        {
+            new() { Description = "Weekly allowance", Amount = 5.00m, Type = TransactionType.Allowance, CreatedAt = DateTime.UtcNow }
+        };
+
+        var cut = RenderComponent<TransactionList>(p => p
+            .Add(x => x.Transactions, transactions));
+
+        Assert.Contains("Weekly allowance", cut.Markup);
+    }
+
+    [Fact]
+    public void Render_Deposit_ShowsPlusPrefix()
+    {
+        var transactions = new List<Transaction>
+        {
+            new() { Amount = 5.00m, Type = TransactionType.Deposit, Description = "Test", CreatedAt = DateTime.UtcNow }
+        };
+
+        var cut = RenderComponent<TransactionList>(p => p
+            .Add(x => x.Transactions, transactions));
+
+        Assert.Contains("+€5.00", cut.Markup);
+    }
+
+    [Fact]
+    public void Render_Withdrawal_ShowsMinusPrefix()
+    {
+        var transactions = new List<Transaction>
+        {
+            new() { Amount = 3.50m, Type = TransactionType.Withdrawal, Description = "Test", CreatedAt = DateTime.UtcNow }
+        };
+
+        var cut = RenderComponent<TransactionList>(p => p
+            .Add(x => x.Transactions, transactions));
+
+        Assert.Contains("-€3.50", cut.Markup);
+    }
+
+    [Fact]
+    public void Render_UsesToLocalForDateDisplay()
+    {
+        var utcDate = new DateTime(2026, 1, 15, 10, 0, 0, DateTimeKind.Utc);
+        var localDate = new DateTime(2026, 1, 15, 11, 0, 0);
+        MockBrowserTime.Setup(x => x.ToLocal(utcDate)).Returns(localDate);
+
+        var transactions = new List<Transaction>
+        {
+            new() { Amount = 5.00m, Type = TransactionType.Deposit, Description = "Test", CreatedAt = utcDate }
+        };
+
+        var cut = RenderComponent<TransactionList>(p => p
+            .Add(x => x.Transactions, transactions));
+
+        Assert.Contains("Jan 15, 2026", cut.Markup);
+        MockBrowserTime.Verify(x => x.ToLocal(utcDate), Times.Once);
+    }
+
+    [Theory]
+    [InlineData(TransactionType.Deposit, "💰")]
+    [InlineData(TransactionType.Withdrawal, "🛍️")]
+    [InlineData(TransactionType.Allowance, "🎁")]
+    public void Render_ShowsCorrectIcon(TransactionType type, string expectedIcon)
+    {
+        var transactions = new List<Transaction>
+        {
+            new() { Amount = 1.00m, Type = type, Description = "Test", CreatedAt = DateTime.UtcNow }
+        };
+
+        var cut = RenderComponent<TransactionList>(p => p
+            .Add(x => x.Transactions, transactions));
+
+        Assert.Contains(expectedIcon, cut.Markup);
+    }
+}

--- a/tests/JunoBank.Web.Tests/Helpers/ComponentTestBase.cs
+++ b/tests/JunoBank.Web.Tests/Helpers/ComponentTestBase.cs
@@ -1,0 +1,29 @@
+using Bunit;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using MudBlazor.Services;
+using JunoBank.Web.Services;
+
+namespace JunoBank.Web.Tests.Helpers;
+
+/// <summary>
+/// Base class for bUnit component tests.
+/// Registers MudBlazor services and common mocks.
+/// </summary>
+public abstract class ComponentTestBase : TestContext
+{
+    protected readonly Mock<IBrowserTimeService> MockBrowserTime;
+
+    protected ComponentTestBase()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddMudServices();
+
+        MockBrowserTime = new Mock<IBrowserTimeService>();
+        MockBrowserTime
+            .Setup(x => x.ToLocal(It.IsAny<DateTime>()))
+            .Returns<DateTime>(dt => dt);
+
+        Services.AddSingleton(MockBrowserTime.Object);
+    }
+}

--- a/tests/JunoBank.Web.Tests/JunoBank.Web.Tests.csproj
+++ b/tests/JunoBank.Web.Tests/JunoBank.Web.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk.Razor">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="bunit" Version="1.*" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\JunoBank.Web\JunoBank.Web.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/JunoBank.Web.Tests/_Imports.razor
+++ b/tests/JunoBank.Web.Tests/_Imports.razor
@@ -1,0 +1,11 @@
+@using Microsoft.AspNetCore.Components.Web
+@using Microsoft.JSInterop
+@using Bunit
+@using Xunit
+@using MudBlazor
+@using JunoBank.Application.DTOs
+@using JunoBank.Application.Interfaces
+@using JunoBank.Domain.Entities
+@using JunoBank.Domain.Enums
+@using JunoBank.Web.Components.Shared
+@using JunoBank.Web.Services


### PR DESCRIPTION
## Summary
- Adds `JunoBank.Web.Tests` project with **21 bUnit tests** for 3 shared components
- Demonstrates 3 test patterns: presentational (ChildCard), stateful (PictureGrid), service-injected (TransactionList)
- Includes `ComponentTestBase` with MudBlazor setup and mock helpers
- Updates `docs/TESTING.md` with bUnit section, patterns, and when-to-use guidance

## Test plan
- [x] All 21 bUnit tests pass (`dotnet test` in `tests/JunoBank.Web.Tests/`)
- [x] All 160 existing unit tests still pass (`dotnet test` in `tests/JunoBank.Tests/`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)